### PR TITLE
cleanup; use ${PATH} and surround '|' with spaces

### DIFF
--- a/userparameters/ZoL_with_sudo.conf
+++ b/userparameters/ZoL_with_sudo.conf
@@ -3,11 +3,11 @@
 
 
 # pool discovery
-UserParameter=zfs.pool.discovery,/usr/bin/sudo /sbin/zpool list -H -o name | /bin/sed -e '$ ! s/\(.*\)/{"{#POOLNAME}":"\1"},/' | /bin/sed -e '$  s/\(.*\)/{"{#POOLNAME}":"\1"}]}/' | /bin/sed -e '1 i { \"data\":['
+UserParameter=zfs.pool.discovery,/usr/bin/sudo /sbin/zpool list -H -o name | sed -e '$ ! s/\(.*\)/{"{#POOLNAME}":"\1"},/' | sed -e '$  s/\(.*\)/{"{#POOLNAME}":"\1"}]}/' | sed -e '1 i { \"data\":['
 # dataset discovery, called "fileset" in the zabbix template for legacy reasons
-UserParameter=zfs.fileset.discovery,/usr/bin/sudo /sbin/zfs list -H -o name | /bin/sed -e '$ ! s/\(.*\)/{"{#FILESETNAME}":"\1"},/' | sed -e '$  s/\(.*\)/{"{#FILESETNAME}":"\1"}]}/' | /bin/sed -e '1 i { \"data\":['
+UserParameter=zfs.fileset.discovery,/usr/bin/sudo /sbin/zfs list -H -o name | sed -e '$ ! s/\(.*\)/{"{#FILESETNAME}":"\1"},/' | sed -e '$  s/\(.*\)/{"{#FILESETNAME}":"\1"}]}/' | sed -e '1 i { \"data\":['
 # vdev discovery
-UserParameter=zfs.vdev.discovery,/usr/bin/sudo /sbin/zpool list -Hv|grep -P "^\t"|egrep -v "mirror|raidz"| awk '{print $1}' | /bin/sed -e '$ ! s/\(.*\)/{"{#VDEV}":"\1"},/' | sed -e '$  s/\(.*\)/{"{#VDEV}":"\1"}]}/' | /bin/sed -e '1 i { \"data\":['
+UserParameter=zfs.vdev.discovery,/usr/bin/sudo /sbin/zpool list -Hv|grep -P "^\t" | egrep -v "mirror|raidz" | awk '{print $1}' | sed -e '$ ! s/\(.*\)/{"{#VDEV}":"\1"},/' | sed -e '$  s/\(.*\)/{"{#VDEV}":"\1"}]}/' | sed -e '1 i { \"data\":['
 
 # pool health
 UserParameter=zfs.zpool.health[*],/usr/bin/sudo /sbin/zpool list -H -o health $1
@@ -29,13 +29,13 @@ UserParameter=zfs.get.param[*],cat /sys/module/zfs/parameters/$1
 UserParameter=zfs.arcstats[*],awk '/^$1/ {printf $$3;}' /proc/spl/kstat/zfs/arcstats
 
 # detect if a scrub is in progress, 0 = in progress, 1 = not in progress
-UserParameter=zfs.zpool.scrub[*],/usr/bin/sudo /sbin/zpool status $1 |grep "scrub in progress" > /dev/null ; echo $?
+UserParameter=zfs.zpool.scrub[*],/usr/bin/sudo /sbin/zpool status $1 | grep "scrub in progress" > /dev/null ; echo $?
 
 # vdev state
-UserParameter=zfs.vdev.state[*],/usr/bin/sudo /sbin/zpool status |grep "$1" | awk '{ print $$2 }'
+UserParameter=zfs.vdev.state[*],/usr/bin/sudo /sbin/zpool status | grep "$1" | awk '{ print $$2 }'
 # vdev READ error counter
-UserParameter=zfs.vdev.error_counter.read[*],/usr/bin/sudo /sbin/zpool status |grep "$1" | awk '{ print $$3 }'
+UserParameter=zfs.vdev.error_counter.read[*],/usr/bin/sudo /sbin/zpool status | grep "$1" | awk '{ print $$3 }'
 # vdev WRITE error counter
-UserParameter=zfs.vdev.error_counter.write[*],/usr/bin/sudo /sbin/zpool status |grep "$1" | awk '{ print $$4 }'
+UserParameter=zfs.vdev.error_counter.write[*],/usr/bin/sudo /sbin/zpool status | grep "$1" | awk '{ print $$4 }'
 # vdev CHECKSUM error counter
-UserParameter=zfs.vdev.error_counter.cksum[*],/usr/bin/sudo /sbin/zpool status |grep "$1" | awk '{ print $$5 }'
+UserParameter=zfs.vdev.error_counter.cksum[*],/usr/bin/sudo /sbin/zpool status | grep "$1" | awk '{ print $$5 }'

--- a/userparameters/ZoL_without_sudo.conf
+++ b/userparameters/ZoL_without_sudo.conf
@@ -3,11 +3,11 @@
 
 
 # pool discovery
-UserParameter=zfs.pool.discovery,/sbin/zpool list -H -o name | /bin/sed -e '$ ! s/\(.*\)/{"{#POOLNAME}":"\1"},/' | /bin/sed -e '$  s/\(.*\)/{"{#POOLNAME}":"\1"}]}/' | /bin/sed -e '1 i { \"data\":['
+UserParameter=zfs.pool.discovery,/sbin/zpool list -H -o name | sed -e '$ ! s/\(.*\)/{"{#POOLNAME}":"\1"},/' | sed -e '$  s/\(.*\)/{"{#POOLNAME}":"\1"}]}/' | sed -e '1 i { \"data\":['
 # dataset discovery, called "fileset" in the zabbix template for legacy reasons
-UserParameter=zfs.fileset.discovery,/sbin/zfs list -H -o name | /bin/sed -e '$ ! s/\(.*\)/{"{#FILESETNAME}":"\1"},/' | sed -e '$  s/\(.*\)/{"{#FILESETNAME}":"\1"}]}/' | /bin/sed -e '1 i { \"data\":['
+UserParameter=zfs.fileset.discovery,/sbin/zfs list -H -o name | sed -e '$ ! s/\(.*\)/{"{#FILESETNAME}":"\1"},/' | sed -e '$  s/\(.*\)/{"{#FILESETNAME}":"\1"}]}/' | sed -e '1 i { \"data\":['
 # vdev discovery
-UserParameter=zfs.vdev.discovery,/sbin/zpool list -Hv|grep -P "^\t"|egrep -v "mirror|raidz"| awk '{print $1}' | /bin/sed -e '$ ! s/\(.*\)/{"{#VDEV}":"\1"},/' | sed -e '$  s/\(.*\)/{"{#VDEV}":"\1"}]}/' | /bin/sed -e '1 i { \"data\":['
+UserParameter=zfs.vdev.discovery,/sbin/zpool list -Hv|grep -P "^\t" | egrep -v "mirror|raidz" | awk '{print $1}' | sed -e '$ ! s/\(.*\)/{"{#VDEV}":"\1"},/' | sed -e '$  s/\(.*\)/{"{#VDEV}":"\1"}]}/' | sed -e '1 i { \"data\":['
 
 # pool health
 UserParameter=zfs.zpool.health[*],/sbin/zpool list -H -o health $1
@@ -29,13 +29,13 @@ UserParameter=zfs.get.param[*],cat /sys/module/zfs/parameters/$1
 UserParameter=zfs.arcstats[*],awk '/^$1/ {printf $$3;}' /proc/spl/kstat/zfs/arcstats
 
 # detect if a scrub is in progress, 0 = in progress, 1 = not in progress
-UserParameter=zfs.zpool.scrub[*],/sbin/zpool status $1 |grep "scrub in progress" > /dev/null ; echo $?
+UserParameter=zfs.zpool.scrub[*],/sbin/zpool status $1 | grep "scrub in progress" > /dev/null ; echo $?
 
 # vdev state
-UserParameter=zfs.vdev.state[*],/sbin/zpool status |grep "$1" | awk '{ print $$2 }'
+UserParameter=zfs.vdev.state[*],/sbin/zpool status | grep "$1" | awk '{ print $$2 }'
 # vdev READ error counter
-UserParameter=zfs.vdev.error_counter.read[*],/sbin/zpool status |grep "$1" | awk '{ print $$3 }'
+UserParameter=zfs.vdev.error_counter.read[*],/sbin/zpool status | grep "$1" | awk '{ print $$3 }'
 # vdev WRITE error counter
-UserParameter=zfs.vdev.error_counter.write[*],/sbin/zpool status |grep "$1" | awk '{ print $$4 }'
+UserParameter=zfs.vdev.error_counter.write[*],/sbin/zpool status | grep "$1" | awk '{ print $$4 }'
 # vdev CHECKSUM error counter
-UserParameter=zfs.vdev.error_counter.cksum[*],/sbin/zpool status |grep "$1" | awk '{ print $$5 }'
+UserParameter=zfs.vdev.error_counter.cksum[*],/sbin/zpool status | grep "$1" | awk '{ print $$5 }'


### PR DESCRIPTION
Some invocations of `sed` are absolute while all other invocations use ${PATH}.
Most pipes are surrounded with white-space while some are not.

Fixed those inconsistencies.