### PR TITLE
Started work for FreeBSD ZFS monitoring

### DIFF
--- a/userparameters/ZoL_without_sudo.conf
+++ b/userparameters/ZoL_without_sudo.conf
@@ -3,11 +3,11 @@
 
 
 # pool discovery
-UserParameter=zfs.pool.discovery,/sbin/zpool list -H -o name | sed -e '$ ! s/\(.*\)/{"{#POOLNAME}":"\1"},/' | sed -e '$  s/\(.*\)/{"{#POOLNAME}":"\1"}]}/' | sed -e '1 i { \"data\":['
+UserParameter=zfs.pool.discovery,/sbin/zpool list -H -o name | sed -e '$ ! s/\(.*\)/{"{#POOLNAME}":"\1"},/' | sed -e '$  s/\(.*\)/{"{#POOLNAME}":"\1"}]}/' | sed -e '1  s/\(.*\)/{ \"data\":[\1/'
 # dataset discovery, called "fileset" in the zabbix template for legacy reasons
-UserParameter=zfs.fileset.discovery,/sbin/zfs list -H -o name | sed -e '$ ! s/\(.*\)/{"{#FILESETNAME}":"\1"},/' | sed -e '$  s/\(.*\)/{"{#FILESETNAME}":"\1"}]}/' | sed -e '1 i { \"data\":['
+UserParameter=zfs.fileset.discovery,/sbin/zfs list -H -o name | sed -e '$ ! s/\(.*\)/{"{#FILESETNAME}":"\1"},/' | sed -e '$  s/\(.*\)/{"{#FILESETNAME}":"\1"}]}/' | sed -e '1  s/\(.*\)/{ \"data\":[\1/'
 # vdev discovery
-UserParameter=zfs.vdev.discovery,/sbin/zpool list -Hv|grep -P "^\t" | egrep -v "mirror|raidz" | awk '{print $1}' | sed -e '$ ! s/\(.*\)/{"{#VDEV}":"\1"},/' | sed -e '$  s/\(.*\)/{"{#VDEV}":"\1"}]}/' | sed -e '1 i { \"data\":['
+UserParameter=zfs.vdev.discovery,/sbin/zpool list -Hv|grep -P "^\t" | egrep -v "mirror|raidz" | awk '{print $1}' | sed -e '$ ! s/\(.*\)/{"{#VDEV}":"\1"},/' | sed -e '$  s/\(.*\)/{"{#VDEV}":"\1"}]}/' | sed -e '1  s/\(.*\)/{ \"data\":[\1/'
 
 # pool health
 UserParameter=zfs.zpool.health[*],/sbin/zpool list -H -o health $1

--- a/userparameters/ZoL_without_sudo.conf
+++ b/userparameters/ZoL_without_sudo.conf
@@ -7,7 +7,7 @@ UserParameter=zfs.pool.discovery,/sbin/zpool list -H -o name | sed -e '$ ! s/\(.
 # dataset discovery, called "fileset" in the zabbix template for legacy reasons
 UserParameter=zfs.fileset.discovery,/sbin/zfs list -H -o name | sed -e '$ ! s/\(.*\)/{"{#FILESETNAME}":"\1"},/' | sed -e '$  s/\(.*\)/{"{#FILESETNAME}":"\1"}]}/' | sed -e '1  s/\(.*\)/{ \"data\":[\1/'
 # vdev discovery
-UserParameter=zfs.vdev.discovery,/sbin/zpool list -Hv|grep -P "^\t" | egrep -v "mirror|raidz" | awk '{print $1}' | sed -e '$ ! s/\(.*\)/{"{#VDEV}":"\1"},/' | sed -e '$  s/\(.*\)/{"{#VDEV}":"\1"}]}/' | sed -e '1  s/\(.*\)/{ \"data\":[\1/'
+UserParameter=zfs.vdev.discovery,/sbin/zpool list -Hv | grep '^[[:blank:]]' | egrep -v 'mirror|raidz' | awk '{print $1}' | sed -e '$ ! s/\(.*\)/{"{#VDEV}":"\1"},/' | sed -e '$  s/\(.*\)/{"{#VDEV}":"\1"}]}/' | sed -e '1  s/\(.*\)/{ \"data\":[\1/'
 
 # pool health
 UserParameter=zfs.zpool.health[*],/sbin/zpool list -H -o health $1


### PR DESCRIPTION
Hi,
as I have some FreeBSD based systems with ZFS in use as well (OPNsense and XigmaNAS) I would love to use this monitoring template there as well.

For the discovery to get to work I had to adjust some of the sed and grep commands. I ran the adjusted commands on Linux and FreeBSD and they produce valid results on both operating systems.

The missing newline after the first line does not seem to matter to Zabbix.

All three discoveries work. 

The things still missing on FreeBSD are the parameters and the arc stats. No idea yet on how to get there yet, but I am already happy with the items I get now into Zabbix so far.