### PR TITLE
If there are more than one VDEVs the graph creation fails.

### DIFF
--- a/template/zol_template.xml
+++ b/template/zol_template.xml
@@ -2122,7 +2122,7 @@ You may also run a zpool scrub to check if some other undetected errors are pres
                     </trigger_prototypes>
                     <graph_prototypes>
                         <graph_prototype>
-                            <name>ZFS vdev errors</name>
+                            <name>ZFS vdev {#VDEV} errors</name>
                             <width>900</width>
                             <height>200</height>
                             <yaxismin>0.0000</yaxismin>


### PR DESCRIPTION
Hi,
while looking through the discovery of our servers I found this problem.

The graph name has to have the {#VDEV} in it as well.

Best regards
Rainer