### PR TITLE
template for zabbix passive checks has been added + readme changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Monitor ZFS on Linux on Zabbix
 
+
+**DISCLAMER:** *Here is a fork unless my pool request wasn't approved for the next reasons: https://github.com/Cosium/zabbix_zfs-on-linux/pull/30*
+
+
 This template is a modified version of the original work done by pbergdolt and posted on the zabbix forum a while ago here: https://www.zabbix.com/forum/zabbix-cookbook/35336-zabbix-zfs-discovery-monitoring?t=43347 . Also the original home of this variant was on https://share.zabbix.com/zfs-on-linux .
 
 I have maintained and modified this template over the years and the different versions of ZoL on a large number of servers so I'm pretty confident that it works ;)

--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ You can see how the macros are used by looking at the discovery rules, then "Tri
 
 # Important note about Zabbix active items
 
-This template uses Zabbix items of type `Zabbix agent (active)` (= active items). By default, most template uses `Zabbix agent` items (= passive items).
+'zol_template.xml' uses Zabbix items of type `Zabbix agent (active)` (= active items). By default, most template uses `Zabbix agent` items (= passive items).
 
-If you want, you can convert all the items to `Zabbix agent` and everything will work, but you should really uses active items because those are way more scalable. The official documentation doesn't really make this point clear (https://www.zabbix.com/documentation/4.0/manual/appendix/items/activepassive) but active items are optimized: the agent asks the server for the list of items that the server wants, then send them by batch periodically.
+If you want, you can convert all the items to `Zabbix agent` or import 'zol_template_passive.xml', but you should really uses active items because those are way more scalable. The official documentation doesn't really make this point clear (https://www.zabbix.com/documentation/4.0/manual/appendix/items/activepassive) but active items are optimized: the agent asks the server for the list of items that the server wants, then send them by batch periodically.
 
 On the other hand, for passive items, the zabbix server must establish a connection for each items and ask for them, then wait for the anwser: this results in more CPU, memory and network consumption used by both the server and the agent.
 

--- a/template/zol_template_passive.xml
+++ b/template/zol_template_passive.xml
@@ -1,0 +1,1444 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<zabbix_export>
+    <version>5.0</version>
+    <date>2021-03-08T19:05:43Z</date>
+    <groups>
+        <group>
+            <name>Templates</name>
+        </group>
+    </groups>
+    <templates>
+        <template>
+            <template>ZFS on Linux</template>
+            <name>ZFS on Linux</name>
+            <description>OpenZFS (formerly ZFS on Linux) template (passive checks).&#13;
+&#13;
+Home of the project: https://github.com/Cosium/zabbix_zfs-on-linux</description>
+            <groups>
+                <group>
+                    <name>Templates</name>
+                </group>
+            </groups>
+            <applications>
+                <application>
+                    <name>ZFS</name>
+                </application>
+                <application>
+                    <name>ZFS ARC</name>
+                </application>
+                <application>
+                    <name>ZFS dataset</name>
+                </application>
+                <application>
+                    <name>ZFS vdev</name>
+                </application>
+                <application>
+                    <name>ZFS zpool</name>
+                </application>
+            </applications>
+            <items>
+                <item>
+                    <name>OpenZFS version</name>
+                    <key>vfs.file.contents[/sys/module/zfs/version]</key>
+                    <delay>1h</delay>
+                    <history>30d</history>
+                    <trends>0</trends>
+                    <value_type>TEXT</value_type>
+                    <applications>
+                        <application>
+                            <name>ZFS</name>
+                        </application>
+                    </applications>
+                    <triggers>
+                        <trigger>
+                            <expression>{diff(0)}&gt;0</expression>
+                            <name>Version of OpenZFS is now {ITEM.VALUE} on {HOST.NAME}</name>
+                            <priority>INFO</priority>
+                        </trigger>
+                    </triggers>
+                </item>
+                <item>
+                    <name>ZFS ARC stat &quot;$1&quot;</name>
+                    <key>zfs.arcstats[arc_dnode_limit]</key>
+                    <history>30d</history>
+                    <units>B</units>
+                    <applications>
+                        <application>
+                            <name>ZFS</name>
+                        </application>
+                        <application>
+                            <name>ZFS ARC</name>
+                        </application>
+                    </applications>
+                </item>
+                <item>
+                    <name>ZFS ARC stat &quot;$1&quot;</name>
+                    <key>zfs.arcstats[arc_meta_limit]</key>
+                    <history>30d</history>
+                    <units>B</units>
+                    <applications>
+                        <application>
+                            <name>ZFS</name>
+                        </application>
+                        <application>
+                            <name>ZFS ARC</name>
+                        </application>
+                    </applications>
+                </item>
+                <item>
+                    <name>ZFS ARC stat &quot;$1&quot;</name>
+                    <key>zfs.arcstats[arc_meta_used]</key>
+                    <history>30d</history>
+                    <units>B</units>
+                    <description>arc_meta_used = hdr_size + metadata_size + dbuf_size + dnode_size + bonus_size</description>
+                    <applications>
+                        <application>
+                            <name>ZFS</name>
+                        </application>
+                        <application>
+                            <name>ZFS ARC</name>
+                        </application>
+                    </applications>
+                </item>
+                <item>
+                    <name>ZFS ARC stat &quot;$1&quot;</name>
+                    <key>zfs.arcstats[bonus_size]</key>
+                    <history>30d</history>
+                    <units>B</units>
+                    <applications>
+                        <application>
+                            <name>ZFS</name>
+                        </application>
+                        <application>
+                            <name>ZFS ARC</name>
+                        </application>
+                    </applications>
+                </item>
+                <item>
+                    <name>ZFS ARC max size</name>
+                    <key>zfs.arcstats[c_max]</key>
+                    <history>30d</history>
+                    <units>B</units>
+                    <applications>
+                        <application>
+                            <name>ZFS</name>
+                        </application>
+                        <application>
+                            <name>ZFS ARC</name>
+                        </application>
+                    </applications>
+                </item>
+                <item>
+                    <name>ZFS ARC minimum size</name>
+                    <key>zfs.arcstats[c_min]</key>
+                    <history>30d</history>
+                    <units>B</units>
+                    <applications>
+                        <application>
+                            <name>ZFS</name>
+                        </application>
+                        <application>
+                            <name>ZFS ARC</name>
+                        </application>
+                    </applications>
+                </item>
+                <item>
+                    <name>ZFS ARC stat &quot;$1&quot;</name>
+                    <key>zfs.arcstats[data_size]</key>
+                    <history>30d</history>
+                    <units>B</units>
+                    <applications>
+                        <application>
+                            <name>ZFS</name>
+                        </application>
+                        <application>
+                            <name>ZFS ARC</name>
+                        </application>
+                    </applications>
+                </item>
+                <item>
+                    <name>ZFS ARC stat &quot;$1&quot;</name>
+                    <key>zfs.arcstats[dbuf_size]</key>
+                    <history>30d</history>
+                    <units>B</units>
+                    <applications>
+                        <application>
+                            <name>ZFS</name>
+                        </application>
+                        <application>
+                            <name>ZFS ARC</name>
+                        </application>
+                    </applications>
+                </item>
+                <item>
+                    <name>ZFS ARC stat &quot;$1&quot;</name>
+                    <key>zfs.arcstats[dnode_size]</key>
+                    <history>30d</history>
+                    <units>B</units>
+                    <applications>
+                        <application>
+                            <name>ZFS</name>
+                        </application>
+                        <application>
+                            <name>ZFS ARC</name>
+                        </application>
+                    </applications>
+                </item>
+                <item>
+                    <name>ZFS ARC stat &quot;$1&quot;</name>
+                    <key>zfs.arcstats[hdr_size]</key>
+                    <history>30d</history>
+                    <units>B</units>
+                    <applications>
+                        <application>
+                            <name>ZFS</name>
+                        </application>
+                        <application>
+                            <name>ZFS ARC</name>
+                        </application>
+                    </applications>
+                </item>
+                <item>
+                    <name>ZFS ARC stat &quot;$1&quot;</name>
+                    <key>zfs.arcstats[hits]</key>
+                    <history>30d</history>
+                    <applications>
+                        <application>
+                            <name>ZFS</name>
+                        </application>
+                        <application>
+                            <name>ZFS ARC</name>
+                        </application>
+                    </applications>
+                    <preprocessing>
+                        <step>
+                            <type>CHANGE_PER_SECOND</type>
+                            <params/>
+                        </step>
+                    </preprocessing>
+                </item>
+                <item>
+                    <name>ZFS ARC stat &quot;$1&quot;</name>
+                    <key>zfs.arcstats[metadata_size]</key>
+                    <history>30d</history>
+                    <units>B</units>
+                    <applications>
+                        <application>
+                            <name>ZFS</name>
+                        </application>
+                        <application>
+                            <name>ZFS ARC</name>
+                        </application>
+                    </applications>
+                </item>
+                <item>
+                    <name>ZFS ARC stat &quot;$1&quot;</name>
+                    <key>zfs.arcstats[mfu_hits]</key>
+                    <history>30d</history>
+                    <applications>
+                        <application>
+                            <name>ZFS</name>
+                        </application>
+                        <application>
+                            <name>ZFS ARC</name>
+                        </application>
+                    </applications>
+                    <preprocessing>
+                        <step>
+                            <type>CHANGE_PER_SECOND</type>
+                            <params/>
+                        </step>
+                    </preprocessing>
+                </item>
+                <item>
+                    <name>ZFS ARC stat &quot;$1&quot;</name>
+                    <key>zfs.arcstats[mfu_size]</key>
+                    <history>30d</history>
+                    <units>B</units>
+                    <applications>
+                        <application>
+                            <name>ZFS</name>
+                        </application>
+                        <application>
+                            <name>ZFS ARC</name>
+                        </application>
+                    </applications>
+                </item>
+                <item>
+                    <name>ZFS ARC stat &quot;$1&quot;</name>
+                    <key>zfs.arcstats[misses]</key>
+                    <history>30d</history>
+                    <applications>
+                        <application>
+                            <name>ZFS</name>
+                        </application>
+                        <application>
+                            <name>ZFS ARC</name>
+                        </application>
+                    </applications>
+                    <preprocessing>
+                        <step>
+                            <type>CHANGE_PER_SECOND</type>
+                            <params/>
+                        </step>
+                    </preprocessing>
+                </item>
+                <item>
+                    <name>ZFS ARC stat &quot;$1&quot;</name>
+                    <key>zfs.arcstats[mru_hits]</key>
+                    <history>30d</history>
+                    <applications>
+                        <application>
+                            <name>ZFS</name>
+                        </application>
+                        <application>
+                            <name>ZFS ARC</name>
+                        </application>
+                    </applications>
+                    <preprocessing>
+                        <step>
+                            <type>CHANGE_PER_SECOND</type>
+                            <params/>
+                        </step>
+                    </preprocessing>
+                </item>
+                <item>
+                    <name>ZFS ARC stat &quot;$1&quot;</name>
+                    <key>zfs.arcstats[mru_size]</key>
+                    <history>30d</history>
+                    <units>B</units>
+                    <applications>
+                        <application>
+                            <name>ZFS</name>
+                        </application>
+                        <application>
+                            <name>ZFS ARC</name>
+                        </application>
+                    </applications>
+                </item>
+                <item>
+                    <name>ZFS ARC current size</name>
+                    <key>zfs.arcstats[size]</key>
+                    <history>30d</history>
+                    <units>B</units>
+                    <applications>
+                        <application>
+                            <name>ZFS</name>
+                        </application>
+                        <application>
+                            <name>ZFS ARC</name>
+                        </application>
+                    </applications>
+                </item>
+                <item>
+                    <name>ZFS ARC Cache Hit Ratio</name>
+                    <type>CALCULATED</type>
+                    <key>zfs.arcstats_hit_ratio</key>
+                    <history>30d</history>
+                    <value_type>FLOAT</value_type>
+                    <units>%</units>
+                    <params>100*(last(zfs.arcstats[hits])/(last(zfs.arcstats[hits])+count(zfs.arcstats[hits],#1,0)+last(zfs.arcstats[misses])))</params>
+                    <applications>
+                        <application>
+                            <name>ZFS</name>
+                        </application>
+                        <application>
+                            <name>ZFS ARC</name>
+                        </application>
+                    </applications>
+                </item>
+                <item>
+                    <name>ZFS ARC total read</name>
+                    <type>CALCULATED</type>
+                    <key>zfs.arcstats_total_read</key>
+                    <history>30d</history>
+                    <units>B</units>
+                    <params>last(zfs.arcstats[hits])+last(zfs.arcstats[misses])</params>
+                    <applications>
+                        <application>
+                            <name>ZFS</name>
+                        </application>
+                        <application>
+                            <name>ZFS ARC</name>
+                        </application>
+                    </applications>
+                </item>
+                <item>
+                    <name>ZFS parameter $1</name>
+                    <key>zfs.get.param[zfs_arc_dnode_limit_percent]</key>
+                    <delay>1h</delay>
+                    <history>30d</history>
+                    <units>%</units>
+                    <applications>
+                        <application>
+                            <name>ZFS</name>
+                        </application>
+                        <application>
+                            <name>ZFS ARC</name>
+                        </application>
+                    </applications>
+                </item>
+                <item>
+                    <name>ZFS parameter $1</name>
+                    <key>zfs.get.param[zfs_arc_meta_limit_percent]</key>
+                    <delay>1h</delay>
+                    <history>30d</history>
+                    <units>%</units>
+                    <applications>
+                        <application>
+                            <name>ZFS</name>
+                        </application>
+                        <application>
+                            <name>ZFS ARC</name>
+                        </application>
+                    </applications>
+                </item>
+            </items>
+            <discovery_rules>
+                <discovery_rule>
+                    <name>Zfs Dataset discovery</name>
+                    <key>zfs.fileset.discovery</key>
+                    <delay>30m</delay>
+                    <filter>
+                        <evaltype>AND</evaltype>
+                    </filter>
+                    <lifetime>2d</lifetime>
+                    <description>Discover ZFS dataset.</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>Zfs dataset $1 compressratio</name>
+                            <key>zfs.get.compressratio[{#FILESETNAME}]</key>
+                            <delay>30m</delay>
+                            <history>30d</history>
+                            <value_type>FLOAT</value_type>
+                            <units>%</units>
+                            <applications>
+                                <application>
+                                    <name>ZFS</name>
+                                </application>
+                                <application>
+                                    <name>ZFS dataset</name>
+                                </application>
+                            </applications>
+                            <preprocessing>
+                                <step>
+                                    <type>MULTIPLIER</type>
+                                    <params>100</params>
+                                </step>
+                            </preprocessing>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Zfs dataset $1 $2</name>
+                            <key>zfs.get.fsinfo[{#FILESETNAME},available]</key>
+                            <delay>5m</delay>
+                            <history>30d</history>
+                            <units>B</units>
+                            <applications>
+                                <application>
+                                    <name>ZFS</name>
+                                </application>
+                                <application>
+                                    <name>ZFS dataset</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Zfs dataset $1 $2</name>
+                            <key>zfs.get.fsinfo[{#FILESETNAME},referenced]</key>
+                            <delay>5m</delay>
+                            <history>30d</history>
+                            <units>B</units>
+                            <applications>
+                                <application>
+                                    <name>ZFS</name>
+                                </application>
+                                <application>
+                                    <name>ZFS dataset</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Zfs dataset $1 $2</name>
+                            <key>zfs.get.fsinfo[{#FILESETNAME},usedbychildren]</key>
+                            <delay>5m</delay>
+                            <history>30d</history>
+                            <units>B</units>
+                            <applications>
+                                <application>
+                                    <name>ZFS</name>
+                                </application>
+                                <application>
+                                    <name>ZFS dataset</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Zfs dataset $1 $2</name>
+                            <key>zfs.get.fsinfo[{#FILESETNAME},usedbydataset]</key>
+                            <delay>1h</delay>
+                            <history>30d</history>
+                            <units>B</units>
+                            <applications>
+                                <application>
+                                    <name>ZFS</name>
+                                </application>
+                                <application>
+                                    <name>ZFS dataset</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Zfs dataset $1 $2</name>
+                            <key>zfs.get.fsinfo[{#FILESETNAME},usedbysnapshots]</key>
+                            <delay>5m</delay>
+                            <history>30d</history>
+                            <units>B</units>
+                            <applications>
+                                <application>
+                                    <name>ZFS</name>
+                                </application>
+                                <application>
+                                    <name>ZFS dataset</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Zfs dataset $1 $2</name>
+                            <key>zfs.get.fsinfo[{#FILESETNAME},used]</key>
+                            <delay>5m</delay>
+                            <history>30d</history>
+                            <units>B</units>
+                            <applications>
+                                <application>
+                                    <name>ZFS</name>
+                                </application>
+                                <application>
+                                    <name>ZFS dataset</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                    </item_prototypes>
+                    <trigger_prototypes>
+                        <trigger_prototype>
+                            <expression>( {ZFS on Linux:zfs.get.fsinfo[{#FILESETNAME},used].last()} / ( {ZFS on Linux:zfs.get.fsinfo[{#FILESETNAME},available].last()} + {ZFS on Linux:zfs.get.fsinfo[{#FILESETNAME},used].last()} ) ) &gt; ({$ZFS_AVERAGE_ALERT}/100)</expression>
+                            <name>More than {$ZFS_AVERAGE_ALERT}% used on dataset {#FILESETNAME} on {HOST.NAME}</name>
+                            <priority>AVERAGE</priority>
+                            <dependencies>
+                                <dependency>
+                                    <name>More than {$ZFS_HIGH_ALERT}% used on dataset {#FILESETNAME} on {HOST.NAME}</name>
+                                    <expression>( {ZFS on Linux:zfs.get.fsinfo[{#FILESETNAME},used].last()} / ( {ZFS on Linux:zfs.get.fsinfo[{#FILESETNAME},available].last()} + {ZFS on Linux:zfs.get.fsinfo[{#FILESETNAME},used].last()} ) ) &gt; ({$ZFS_HIGH_ALERT}/100)</expression>
+                                </dependency>
+                            </dependencies>
+                        </trigger_prototype>
+                        <trigger_prototype>
+                            <expression>( {ZFS on Linux:zfs.get.fsinfo[{#FILESETNAME},used].last()} / ( {ZFS on Linux:zfs.get.fsinfo[{#FILESETNAME},available].last()} + {ZFS on Linux:zfs.get.fsinfo[{#FILESETNAME},used].last()} ) ) &gt; ({$ZFS_DISASTER_ALERT}/100)</expression>
+                            <name>More than {$ZFS_DISASTER_ALERT}% used on dataset {#FILESETNAME} on {HOST.NAME}</name>
+                            <priority>DISASTER</priority>
+                        </trigger_prototype>
+                        <trigger_prototype>
+                            <expression>( {ZFS on Linux:zfs.get.fsinfo[{#FILESETNAME},used].last()} / ( {ZFS on Linux:zfs.get.fsinfo[{#FILESETNAME},available].last()} + {ZFS on Linux:zfs.get.fsinfo[{#FILESETNAME},used].last()} ) ) &gt; ({$ZFS_HIGH_ALERT}/100)</expression>
+                            <name>More than {$ZFS_HIGH_ALERT}% used on dataset {#FILESETNAME} on {HOST.NAME}</name>
+                            <priority>HIGH</priority>
+                            <dependencies>
+                                <dependency>
+                                    <name>More than {$ZFS_DISASTER_ALERT}% used on dataset {#FILESETNAME} on {HOST.NAME}</name>
+                                    <expression>( {ZFS on Linux:zfs.get.fsinfo[{#FILESETNAME},used].last()} / ( {ZFS on Linux:zfs.get.fsinfo[{#FILESETNAME},available].last()} + {ZFS on Linux:zfs.get.fsinfo[{#FILESETNAME},used].last()} ) ) &gt; ({$ZFS_DISASTER_ALERT}/100)</expression>
+                                </dependency>
+                            </dependencies>
+                        </trigger_prototype>
+                    </trigger_prototypes>
+                    <graph_prototypes>
+                        <graph_prototype>
+                            <name>ZFS dataset {#FILESETNAME} usage</name>
+                            <type>STACKED</type>
+                            <ymin_type_1>FIXED</ymin_type_1>
+                            <graph_items>
+                                <graph_item>
+                                    <sortorder>1</sortorder>
+                                    <color>3333FF</color>
+                                    <item>
+                                        <host>ZFS on Linux</host>
+                                        <key>zfs.get.fsinfo[{#FILESETNAME},usedbydataset]</key>
+                                    </item>
+                                </graph_item>
+                                <graph_item>
+                                    <sortorder>2</sortorder>
+                                    <color>FF33FF</color>
+                                    <item>
+                                        <host>ZFS on Linux</host>
+                                        <key>zfs.get.fsinfo[{#FILESETNAME},usedbysnapshots]</key>
+                                    </item>
+                                </graph_item>
+                                <graph_item>
+                                    <sortorder>3</sortorder>
+                                    <color>FF3333</color>
+                                    <item>
+                                        <host>ZFS on Linux</host>
+                                        <key>zfs.get.fsinfo[{#FILESETNAME},usedbychildren]</key>
+                                    </item>
+                                </graph_item>
+                                <graph_item>
+                                    <sortorder>4</sortorder>
+                                    <color>33FF33</color>
+                                    <item>
+                                        <host>ZFS on Linux</host>
+                                        <key>zfs.get.fsinfo[{#FILESETNAME},available]</key>
+                                    </item>
+                                </graph_item>
+                            </graph_items>
+                        </graph_prototype>
+                    </graph_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>Zfs Pool discovery</name>
+                    <key>zfs.pool.discovery</key>
+                    <delay>1h</delay>
+                    <lifetime>3d</lifetime>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>Zpool {#POOLNAME}: Get iostats</name>
+                            <key>vfs.file.contents[/proc/spl/kstat/zfs/{#POOLNAME}/io]</key>
+                            <history>0</history>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <applications>
+                                <application>
+                                    <name>ZFS</name>
+                                </application>
+                                <application>
+                                    <name>ZFS zpool</name>
+                                </application>
+                            </applications>
+                            <preprocessing>
+                                <step>
+                                    <type>REGEX</type>
+                                    <params>([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+).*$
+[&quot;\1&quot;, &quot;\2&quot;, &quot;\3&quot;, &quot;\4&quot;]</params>
+                                </step>
+                            </preprocessing>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Zpool {#POOLNAME} available</name>
+                            <key>zfs.get.fsinfo[{#POOLNAME},available]</key>
+                            <delay>5m</delay>
+                            <history>30d</history>
+                            <units>B</units>
+                            <applications>
+                                <application>
+                                    <name>ZFS</name>
+                                </application>
+                                <application>
+                                    <name>ZFS zpool</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Zpool {#POOLNAME} used</name>
+                            <key>zfs.get.fsinfo[{#POOLNAME},used]</key>
+                            <delay>5m</delay>
+                            <history>30d</history>
+                            <units>B</units>
+                            <applications>
+                                <application>
+                                    <name>ZFS</name>
+                                </application>
+                                <application>
+                                    <name>ZFS zpool</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Zpool {#POOLNAME} Health</name>
+                            <key>zfs.zpool.health[{#POOLNAME}]</key>
+                            <delay>5m</delay>
+                            <history>30d</history>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <applications>
+                                <application>
+                                    <name>ZFS</name>
+                                </application>
+                                <application>
+                                    <name>ZFS zpool</name>
+                                </application>
+                            </applications>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{str(ONLINE)}=0</expression>
+                                    <name>Zpool {#POOLNAME} is {ITEM.VALUE} on {HOST.NAME}</name>
+                                    <priority>HIGH</priority>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Zpool {#POOLNAME} read throughput</name>
+                            <type>DEPENDENT</type>
+                            <key>zfs.zpool.iostat.nread[{#POOLNAME}]</key>
+                            <delay>0</delay>
+                            <history>30d</history>
+                            <value_type>FLOAT</value_type>
+                            <units>Bps</units>
+                            <applications>
+                                <application>
+                                    <name>ZFS</name>
+                                </application>
+                                <application>
+                                    <name>ZFS zpool</name>
+                                </application>
+                            </applications>
+                            <preprocessing>
+                                <step>
+                                    <type>JSONPATH</type>
+                                    <params>$[0]</params>
+                                </step>
+                                <step>
+                                    <type>CHANGE_PER_SECOND</type>
+                                    <params/>
+                                </step>
+                            </preprocessing>
+                            <master_item>
+                                <key>vfs.file.contents[/proc/spl/kstat/zfs/{#POOLNAME}/io]</key>
+                            </master_item>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Zpool {#POOLNAME} write throughput</name>
+                            <type>DEPENDENT</type>
+                            <key>zfs.zpool.iostat.nwritten[{#POOLNAME}]</key>
+                            <delay>0</delay>
+                            <history>30d</history>
+                            <value_type>FLOAT</value_type>
+                            <units>Bps</units>
+                            <applications>
+                                <application>
+                                    <name>ZFS</name>
+                                </application>
+                                <application>
+                                    <name>ZFS zpool</name>
+                                </application>
+                            </applications>
+                            <preprocessing>
+                                <step>
+                                    <type>JSONPATH</type>
+                                    <params>$[1]</params>
+                                </step>
+                                <step>
+                                    <type>CHANGE_PER_SECOND</type>
+                                    <params/>
+                                </step>
+                            </preprocessing>
+                            <master_item>
+                                <key>vfs.file.contents[/proc/spl/kstat/zfs/{#POOLNAME}/io]</key>
+                            </master_item>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Zpool {#POOLNAME} IOPS: reads</name>
+                            <type>DEPENDENT</type>
+                            <key>zfs.zpool.iostat.reads[{#POOLNAME}]</key>
+                            <delay>0</delay>
+                            <history>30d</history>
+                            <value_type>FLOAT</value_type>
+                            <units>iops</units>
+                            <applications>
+                                <application>
+                                    <name>ZFS</name>
+                                </application>
+                                <application>
+                                    <name>ZFS zpool</name>
+                                </application>
+                            </applications>
+                            <preprocessing>
+                                <step>
+                                    <type>JSONPATH</type>
+                                    <params>$[2]</params>
+                                </step>
+                                <step>
+                                    <type>CHANGE_PER_SECOND</type>
+                                    <params/>
+                                </step>
+                            </preprocessing>
+                            <master_item>
+                                <key>vfs.file.contents[/proc/spl/kstat/zfs/{#POOLNAME}/io]</key>
+                            </master_item>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Zpool {#POOLNAME} IOPS: writes</name>
+                            <type>DEPENDENT</type>
+                            <key>zfs.zpool.iostat.writes[{#POOLNAME}]</key>
+                            <delay>0</delay>
+                            <history>30d</history>
+                            <value_type>FLOAT</value_type>
+                            <units>iops</units>
+                            <applications>
+                                <application>
+                                    <name>ZFS</name>
+                                </application>
+                                <application>
+                                    <name>ZFS zpool</name>
+                                </application>
+                            </applications>
+                            <preprocessing>
+                                <step>
+                                    <type>JSONPATH</type>
+                                    <params>$[3]</params>
+                                </step>
+                                <step>
+                                    <type>CHANGE_PER_SECOND</type>
+                                    <params/>
+                                </step>
+                            </preprocessing>
+                            <master_item>
+                                <key>vfs.file.contents[/proc/spl/kstat/zfs/{#POOLNAME}/io]</key>
+                            </master_item>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Zpool {#POOLNAME} scrub status</name>
+                            <key>zfs.zpool.scrub[{#POOLNAME}]</key>
+                            <delay>5m</delay>
+                            <history>30d</history>
+                            <description>Detect if the pool is currently scrubbing itself.&#13;
+&#13;
+This is not a bad thing itself, but it slows down the entire pool and should be terminated when on production server during business hours if it causes a noticeable slowdown.</description>
+                            <applications>
+                                <application>
+                                    <name>ZFS</name>
+                                </application>
+                                <application>
+                                    <name>ZFS zpool</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>ZFS zpool scrub status</name>
+                            </valuemap>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{max(12h)}=0</expression>
+                                    <name>Zpool {#POOLNAME} is scrubbing for more than 12h on {HOST.NAME}</name>
+                                    <priority>AVERAGE</priority>
+                                    <dependencies>
+                                        <dependency>
+                                            <name>Zpool {#POOLNAME} is scrubbing for more than 24h on {HOST.NAME}</name>
+                                            <expression>{ZFS on Linux:zfs.zpool.scrub[{#POOLNAME}].max(24h)}=0</expression>
+                                        </dependency>
+                                    </dependencies>
+                                </trigger_prototype>
+                                <trigger_prototype>
+                                    <expression>{max(24h)}=0</expression>
+                                    <name>Zpool {#POOLNAME} is scrubbing for more than 24h on {HOST.NAME}</name>
+                                    <priority>HIGH</priority>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+                    <trigger_prototypes>
+                        <trigger_prototype>
+                            <expression>( {ZFS on Linux:zfs.get.fsinfo[{#POOLNAME},used].last()} / ( {ZFS on Linux:zfs.get.fsinfo[{#POOLNAME},available].last()} + {ZFS on Linux:zfs.get.fsinfo[{#POOLNAME},used].last()} ) ) &gt; ({$ZPOOL_AVERAGE_ALERT}/100)</expression>
+                            <name>More than {$ZPOOL_AVERAGE_ALERT}% used on zpool {#POOLNAME} on {HOST.NAME}</name>
+                            <priority>AVERAGE</priority>
+                            <dependencies>
+                                <dependency>
+                                    <name>More than {$ZPOOL_HIGH_ALERT}% used on zpool {#POOLNAME} on {HOST.NAME}</name>
+                                    <expression>( {ZFS on Linux:zfs.get.fsinfo[{#POOLNAME},used].last()} / ( {ZFS on Linux:zfs.get.fsinfo[{#POOLNAME},available].last()} + {ZFS on Linux:zfs.get.fsinfo[{#POOLNAME},used].last()} ) ) &gt; ({$ZPOOL_HIGH_ALERT}/100)</expression>
+                                </dependency>
+                            </dependencies>
+                        </trigger_prototype>
+                        <trigger_prototype>
+                            <expression>( {ZFS on Linux:zfs.get.fsinfo[{#POOLNAME},used].last()} / ( {ZFS on Linux:zfs.get.fsinfo[{#POOLNAME},available].last()} + {ZFS on Linux:zfs.get.fsinfo[{#POOLNAME},used].last()} ) ) &gt; ({$ZPOOL_DISASTER_ALERT}/100)</expression>
+                            <name>More than {$ZPOOL_DISASTER_ALERT}% used on zpool {#POOLNAME} on {HOST.NAME}</name>
+                            <priority>DISASTER</priority>
+                        </trigger_prototype>
+                        <trigger_prototype>
+                            <expression>( {ZFS on Linux:zfs.get.fsinfo[{#POOLNAME},used].last()} / ( {ZFS on Linux:zfs.get.fsinfo[{#POOLNAME},available].last()} + {ZFS on Linux:zfs.get.fsinfo[{#POOLNAME},used].last()} ) ) &gt; ({$ZPOOL_HIGH_ALERT}/100)</expression>
+                            <name>More than {$ZPOOL_HIGH_ALERT}% used on zpool {#POOLNAME} on {HOST.NAME}</name>
+                            <priority>HIGH</priority>
+                            <dependencies>
+                                <dependency>
+                                    <name>More than {$ZPOOL_DISASTER_ALERT}% used on zpool {#POOLNAME} on {HOST.NAME}</name>
+                                    <expression>( {ZFS on Linux:zfs.get.fsinfo[{#POOLNAME},used].last()} / ( {ZFS on Linux:zfs.get.fsinfo[{#POOLNAME},available].last()} + {ZFS on Linux:zfs.get.fsinfo[{#POOLNAME},used].last()} ) ) &gt; ({$ZPOOL_DISASTER_ALERT}/100)</expression>
+                                </dependency>
+                            </dependencies>
+                        </trigger_prototype>
+                    </trigger_prototypes>
+                    <graph_prototypes>
+                        <graph_prototype>
+                            <name>ZFS zpool {#POOLNAME} IOPS</name>
+                            <ymin_type_1>FIXED</ymin_type_1>
+                            <graph_items>
+                                <graph_item>
+                                    <sortorder>1</sortorder>
+                                    <color>5C6BC0</color>
+                                    <item>
+                                        <host>ZFS on Linux</host>
+                                        <key>zfs.zpool.iostat.reads[{#POOLNAME}]</key>
+                                    </item>
+                                </graph_item>
+                                <graph_item>
+                                    <sortorder>2</sortorder>
+                                    <color>EF5350</color>
+                                    <item>
+                                        <host>ZFS on Linux</host>
+                                        <key>zfs.zpool.iostat.writes[{#POOLNAME}]</key>
+                                    </item>
+                                </graph_item>
+                            </graph_items>
+                        </graph_prototype>
+                        <graph_prototype>
+                            <name>ZFS zpool {#POOLNAME} space usage</name>
+                            <type>STACKED</type>
+                            <graph_items>
+                                <graph_item>
+                                    <sortorder>1</sortorder>
+                                    <color>00EE00</color>
+                                    <item>
+                                        <host>ZFS on Linux</host>
+                                        <key>zfs.get.fsinfo[{#POOLNAME},available]</key>
+                                    </item>
+                                </graph_item>
+                                <graph_item>
+                                    <sortorder>2</sortorder>
+                                    <color>EE0000</color>
+                                    <item>
+                                        <host>ZFS on Linux</host>
+                                        <key>zfs.get.fsinfo[{#POOLNAME},used]</key>
+                                    </item>
+                                </graph_item>
+                            </graph_items>
+                        </graph_prototype>
+                        <graph_prototype>
+                            <name>ZFS zpool {#POOLNAME} throughput</name>
+                            <ymin_type_1>FIXED</ymin_type_1>
+                            <graph_items>
+                                <graph_item>
+                                    <sortorder>1</sortorder>
+                                    <color>5C6BC0</color>
+                                    <item>
+                                        <host>ZFS on Linux</host>
+                                        <key>zfs.zpool.iostat.nread[{#POOLNAME}]</key>
+                                    </item>
+                                </graph_item>
+                                <graph_item>
+                                    <sortorder>2</sortorder>
+                                    <drawtype>BOLD_LINE</drawtype>
+                                    <color>EF5350</color>
+                                    <item>
+                                        <host>ZFS on Linux</host>
+                                        <key>zfs.zpool.iostat.nwritten[{#POOLNAME}]</key>
+                                    </item>
+                                </graph_item>
+                            </graph_items>
+                        </graph_prototype>
+                    </graph_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>Zfs vdev discovery</name>
+                    <key>zfs.vdev.discovery</key>
+                    <delay>1h</delay>
+                    <lifetime>3d</lifetime>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>vdev {#VDEV}: CHECKSUM error counter</name>
+                            <key>zfs.vdev.error_counter.cksum[{#VDEV}]</key>
+                            <delay>5m</delay>
+                            <history>30d</history>
+                            <description>This device has experienced an unrecoverable error. Determine if the device needs to be replaced.&#13;
+&#13;
+If yes, use 'zpool replace' to replace the device.&#13;
+&#13;
+If not, clear the error with 'zpool clear'.</description>
+                            <applications>
+                                <application>
+                                    <name>ZFS</name>
+                                </application>
+                                <application>
+                                    <name>ZFS vdev</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>vdev {#VDEV}: READ error counter</name>
+                            <key>zfs.vdev.error_counter.read[{#VDEV}]</key>
+                            <delay>5m</delay>
+                            <history>30d</history>
+                            <description>This device has experienced an unrecoverable error. Determine if the device needs to be replaced.&#13;
+&#13;
+If yes, use 'zpool replace' to replace the device.&#13;
+&#13;
+If not, clear the error with 'zpool clear'.</description>
+                            <applications>
+                                <application>
+                                    <name>ZFS</name>
+                                </application>
+                                <application>
+                                    <name>ZFS vdev</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>vdev {#VDEV}: WRITE error counter</name>
+                            <key>zfs.vdev.error_counter.write[{#VDEV}]</key>
+                            <delay>5m</delay>
+                            <history>30d</history>
+                            <description>This device has experienced an unrecoverable error. Determine if the device needs to be replaced.&#13;
+&#13;
+If yes, use 'zpool replace' to replace the device.&#13;
+&#13;
+If not, clear the error with 'zpool clear'.</description>
+                            <applications>
+                                <application>
+                                    <name>ZFS</name>
+                                </application>
+                                <application>
+                                    <name>ZFS vdev</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>vdev {#VDEV}: total number of errors</name>
+                            <type>CALCULATED</type>
+                            <key>zfs.vdev.error_total[{#VDEV}]</key>
+                            <delay>5m</delay>
+                            <history>30d</history>
+                            <params>last(zfs.vdev.error_counter.cksum[{#VDEV}])+last(zfs.vdev.error_counter.read[{#VDEV}])+last(zfs.vdev.error_counter.write[{#VDEV}])</params>
+                            <description>This device has experienced an unrecoverable error. Determine if the device needs to be replaced.&#13;
+&#13;
+If yes, use 'zpool replace' to replace the device.&#13;
+&#13;
+If not, clear the error with 'zpool clear'.</description>
+                            <applications>
+                                <application>
+                                    <name>ZFS</name>
+                                </application>
+                                <application>
+                                    <name>ZFS vdev</name>
+                                </application>
+                            </applications>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{last()}&gt;0</expression>
+                                    <name>vdev {#VDEV} has encountered {ITEM.VALUE} errors on {HOST.NAME}</name>
+                                    <priority>HIGH</priority>
+                                    <description>This device has experienced an unrecoverable error. Determine if the device needs to be replaced.&#13;
+&#13;
+If yes, use 'zpool replace' to replace the device.&#13;
+&#13;
+If not, clear the error with 'zpool clear'.&#13;
+&#13;
+You may also run a zpool scrub to check if some other undetected errors are present on this vdev.</description>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+                    <graph_prototypes>
+                        <graph_prototype>
+                            <name>ZFS vdev {#VDEV} errors</name>
+                            <ymin_type_1>FIXED</ymin_type_1>
+                            <graph_items>
+                                <graph_item>
+                                    <color>CC00CC</color>
+                                    <item>
+                                        <host>ZFS on Linux</host>
+                                        <key>zfs.vdev.error_counter.cksum[{#VDEV}]</key>
+                                    </item>
+                                </graph_item>
+                                <graph_item>
+                                    <sortorder>1</sortorder>
+                                    <color>F63100</color>
+                                    <item>
+                                        <host>ZFS on Linux</host>
+                                        <key>zfs.vdev.error_counter.read[{#VDEV}]</key>
+                                    </item>
+                                </graph_item>
+                                <graph_item>
+                                    <sortorder>2</sortorder>
+                                    <color>BBBB00</color>
+                                    <item>
+                                        <host>ZFS on Linux</host>
+                                        <key>zfs.vdev.error_counter.write[{#VDEV}]</key>
+                                    </item>
+                                </graph_item>
+                            </graph_items>
+                        </graph_prototype>
+                    </graph_prototypes>
+                </discovery_rule>
+            </discovery_rules>
+            <macros>
+                <macro>
+                    <macro>{$ZFS_ARC_META_ALERT}</macro>
+                    <value>90</value>
+                </macro>
+                <macro>
+                    <macro>{$ZFS_AVERAGE_ALERT}</macro>
+                    <value>90</value>
+                </macro>
+                <macro>
+                    <macro>{$ZFS_DISASTER_ALERT}</macro>
+                    <value>99</value>
+                </macro>
+                <macro>
+                    <macro>{$ZFS_HIGH_ALERT}</macro>
+                    <value>95</value>
+                </macro>
+                <macro>
+                    <macro>{$ZPOOL_AVERAGE_ALERT}</macro>
+                    <value>85</value>
+                </macro>
+                <macro>
+                    <macro>{$ZPOOL_DISASTER_ALERT}</macro>
+                    <value>99</value>
+                </macro>
+                <macro>
+                    <macro>{$ZPOOL_HIGH_ALERT}</macro>
+                    <value>90</value>
+                </macro>
+            </macros>
+            <screens>
+                <screen>
+                    <name>ZFS ARC</name>
+                    <hsize>1</hsize>
+                    <vsize>4</vsize>
+                    <screen_items>
+                        <screen_item>
+                            <resourcetype>0</resourcetype>
+                            <style>0</style>
+                            <resource>
+                                <name>ZFS ARC memory usage</name>
+                                <host>ZFS on Linux</host>
+                            </resource>
+                            <width>1500</width>
+                            <height>150</height>
+                            <x>0</x>
+                            <y>0</y>
+                            <colspan>1</colspan>
+                            <rowspan>1</rowspan>
+                            <elements>0</elements>
+                            <valign>0</valign>
+                            <halign>0</halign>
+                            <dynamic>0</dynamic>
+                            <sort_triggers>0</sort_triggers>
+                            <url/>
+                            <application/>
+                            <max_columns>3</max_columns>
+                        </screen_item>
+                        <screen_item>
+                            <resourcetype>0</resourcetype>
+                            <style>0</style>
+                            <resource>
+                                <name>ZFS ARC Cache Hit Ratio</name>
+                                <host>ZFS on Linux</host>
+                            </resource>
+                            <width>1500</width>
+                            <height>150</height>
+                            <x>0</x>
+                            <y>1</y>
+                            <colspan>1</colspan>
+                            <rowspan>1</rowspan>
+                            <elements>0</elements>
+                            <valign>0</valign>
+                            <halign>0</halign>
+                            <dynamic>0</dynamic>
+                            <sort_triggers>0</sort_triggers>
+                            <url/>
+                            <application/>
+                            <max_columns>3</max_columns>
+                        </screen_item>
+                        <screen_item>
+                            <resourcetype>0</resourcetype>
+                            <style>0</style>
+                            <resource>
+                                <name>ZFS ARC breakdown</name>
+                                <host>ZFS on Linux</host>
+                            </resource>
+                            <width>1500</width>
+                            <height>150</height>
+                            <x>0</x>
+                            <y>2</y>
+                            <colspan>1</colspan>
+                            <rowspan>1</rowspan>
+                            <elements>0</elements>
+                            <valign>0</valign>
+                            <halign>0</halign>
+                            <dynamic>0</dynamic>
+                            <sort_triggers>0</sort_triggers>
+                            <url/>
+                            <application/>
+                            <max_columns>3</max_columns>
+                        </screen_item>
+                        <screen_item>
+                            <resourcetype>0</resourcetype>
+                            <style>0</style>
+                            <resource>
+                                <name>ZFS ARC arc_meta_used breakdown</name>
+                                <host>ZFS on Linux</host>
+                            </resource>
+                            <width>1500</width>
+                            <height>150</height>
+                            <x>0</x>
+                            <y>3</y>
+                            <colspan>1</colspan>
+                            <rowspan>1</rowspan>
+                            <elements>0</elements>
+                            <valign>0</valign>
+                            <halign>0</halign>
+                            <dynamic>0</dynamic>
+                            <sort_triggers>0</sort_triggers>
+                            <url/>
+                            <application/>
+                            <max_columns>3</max_columns>
+                        </screen_item>
+                    </screen_items>
+                </screen>
+                <screen>
+                    <name>ZFS zpools</name>
+                    <hsize>3</hsize>
+                    <vsize>1</vsize>
+                    <screen_items>
+                        <screen_item>
+                            <resourcetype>20</resourcetype>
+                            <style>0</style>
+                            <resource>
+                                <name>ZFS zpool {#POOLNAME} IOPS</name>
+                                <host>ZFS on Linux</host>
+                            </resource>
+                            <width>400</width>
+                            <height>100</height>
+                            <x>0</x>
+                            <y>0</y>
+                            <colspan>1</colspan>
+                            <rowspan>1</rowspan>
+                            <elements>0</elements>
+                            <valign>0</valign>
+                            <halign>0</halign>
+                            <dynamic>0</dynamic>
+                            <sort_triggers>0</sort_triggers>
+                            <url/>
+                            <application/>
+                            <max_columns>1</max_columns>
+                        </screen_item>
+                        <screen_item>
+                            <resourcetype>20</resourcetype>
+                            <style>0</style>
+                            <resource>
+                                <name>ZFS zpool {#POOLNAME} throughput</name>
+                                <host>ZFS on Linux</host>
+                            </resource>
+                            <width>400</width>
+                            <height>100</height>
+                            <x>1</x>
+                            <y>0</y>
+                            <colspan>1</colspan>
+                            <rowspan>1</rowspan>
+                            <elements>0</elements>
+                            <valign>0</valign>
+                            <halign>0</halign>
+                            <dynamic>0</dynamic>
+                            <sort_triggers>0</sort_triggers>
+                            <url/>
+                            <application/>
+                            <max_columns>1</max_columns>
+                        </screen_item>
+                        <screen_item>
+                            <resourcetype>20</resourcetype>
+                            <style>0</style>
+                            <resource>
+                                <name>ZFS zpool {#POOLNAME} space usage</name>
+                                <host>ZFS on Linux</host>
+                            </resource>
+                            <width>400</width>
+                            <height>100</height>
+                            <x>2</x>
+                            <y>0</y>
+                            <colspan>1</colspan>
+                            <rowspan>1</rowspan>
+                            <elements>0</elements>
+                            <valign>0</valign>
+                            <halign>0</halign>
+                            <dynamic>0</dynamic>
+                            <sort_triggers>0</sort_triggers>
+                            <url/>
+                            <application/>
+                            <max_columns>1</max_columns>
+                        </screen_item>
+                    </screen_items>
+                </screen>
+            </screens>
+        </template>
+    </templates>
+    <triggers>
+        <trigger>
+            <expression>{ZFS on Linux:zfs.arcstats[dnode_size].last()}&gt;({ZFS on Linux:zfs.arcstats[arc_dnode_limit].last()}*0.9)</expression>
+            <name>ZFS ARC dnode size &gt; 90% dnode max size on {HOST.NAME}</name>
+            <priority>HIGH</priority>
+        </trigger>
+        <trigger>
+            <expression>{ZFS on Linux:zfs.arcstats[arc_meta_used].last()}&gt;({ZFS on Linux:zfs.arcstats[arc_meta_limit].last()}*0.01*{$ZFS_ARC_META_ALERT})</expression>
+            <name>ZFS ARC meta size &gt; {$ZFS_ARC_META_ALERT}% meta max size on {HOST.NAME}</name>
+            <priority>HIGH</priority>
+        </trigger>
+    </triggers>
+    <graphs>
+        <graph>
+            <name>ZFS ARC arc_meta_used breakdown</name>
+            <type>STACKED</type>
+            <ymin_type_1>FIXED</ymin_type_1>
+            <graph_items>
+                <graph_item>
+                    <color>3333FF</color>
+                    <item>
+                        <host>ZFS on Linux</host>
+                        <key>zfs.arcstats[metadata_size]</key>
+                    </item>
+                </graph_item>
+                <graph_item>
+                    <sortorder>1</sortorder>
+                    <color>00EE00</color>
+                    <item>
+                        <host>ZFS on Linux</host>
+                        <key>zfs.arcstats[dnode_size]</key>
+                    </item>
+                </graph_item>
+                <graph_item>
+                    <sortorder>2</sortorder>
+                    <color>EE0000</color>
+                    <item>
+                        <host>ZFS on Linux</host>
+                        <key>zfs.arcstats[hdr_size]</key>
+                    </item>
+                </graph_item>
+                <graph_item>
+                    <sortorder>3</sortorder>
+                    <color>EEEE00</color>
+                    <item>
+                        <host>ZFS on Linux</host>
+                        <key>zfs.arcstats[dbuf_size]</key>
+                    </item>
+                </graph_item>
+                <graph_item>
+                    <sortorder>4</sortorder>
+                    <color>EE00EE</color>
+                    <item>
+                        <host>ZFS on Linux</host>
+                        <key>zfs.arcstats[bonus_size]</key>
+                    </item>
+                </graph_item>
+            </graph_items>
+        </graph>
+        <graph>
+            <name>ZFS ARC breakdown</name>
+            <type>STACKED</type>
+            <ymin_type_1>FIXED</ymin_type_1>
+            <graph_items>
+                <graph_item>
+                    <color>3333FF</color>
+                    <item>
+                        <host>ZFS on Linux</host>
+                        <key>zfs.arcstats[data_size]</key>
+                    </item>
+                </graph_item>
+                <graph_item>
+                    <sortorder>1</sortorder>
+                    <color>00AA00</color>
+                    <item>
+                        <host>ZFS on Linux</host>
+                        <key>zfs.arcstats[metadata_size]</key>
+                    </item>
+                </graph_item>
+                <graph_item>
+                    <sortorder>2</sortorder>
+                    <color>EE0000</color>
+                    <item>
+                        <host>ZFS on Linux</host>
+                        <key>zfs.arcstats[dnode_size]</key>
+                    </item>
+                </graph_item>
+                <graph_item>
+                    <sortorder>3</sortorder>
+                    <color>CCCC00</color>
+                    <item>
+                        <host>ZFS on Linux</host>
+                        <key>zfs.arcstats[hdr_size]</key>
+                    </item>
+                </graph_item>
+                <graph_item>
+                    <sortorder>4</sortorder>
+                    <color>A54F10</color>
+                    <item>
+                        <host>ZFS on Linux</host>
+                        <key>zfs.arcstats[dbuf_size]</key>
+                    </item>
+                </graph_item>
+                <graph_item>
+                    <sortorder>5</sortorder>
+                    <color>888888</color>
+                    <item>
+                        <host>ZFS on Linux</host>
+                        <key>zfs.arcstats[bonus_size]</key>
+                    </item>
+                </graph_item>
+            </graph_items>
+        </graph>
+        <graph>
+            <name>ZFS ARC Cache Hit Ratio</name>
+            <ymin_type_1>FIXED</ymin_type_1>
+            <ymax_type_1>FIXED</ymax_type_1>
+            <graph_items>
+                <graph_item>
+                    <color>00CC00</color>
+                    <item>
+                        <host>ZFS on Linux</host>
+                        <key>zfs.arcstats_hit_ratio</key>
+                    </item>
+                </graph_item>
+            </graph_items>
+        </graph>
+        <graph>
+            <name>ZFS ARC memory usage</name>
+            <ymin_type_1>FIXED</ymin_type_1>
+            <ymax_type_1>ITEM</ymax_type_1>
+            <ymax_item_1>
+                <host>ZFS on Linux</host>
+                <key>zfs.arcstats[c_max]</key>
+            </ymax_item_1>
+            <graph_items>
+                <graph_item>
+                    <drawtype>GRADIENT_LINE</drawtype>
+                    <color>0000EE</color>
+                    <item>
+                        <host>ZFS on Linux</host>
+                        <key>zfs.arcstats[size]</key>
+                    </item>
+                </graph_item>
+                <graph_item>
+                    <sortorder>1</sortorder>
+                    <drawtype>BOLD_LINE</drawtype>
+                    <color>DD0000</color>
+                    <item>
+                        <host>ZFS on Linux</host>
+                        <key>zfs.arcstats[c_max]</key>
+                    </item>
+                </graph_item>
+                <graph_item>
+                    <sortorder>2</sortorder>
+                    <color>00BB00</color>
+                    <item>
+                        <host>ZFS on Linux</host>
+                        <key>zfs.arcstats[c_min]</key>
+                    </item>
+                </graph_item>
+            </graph_items>
+        </graph>
+    </graphs>
+    <value_maps>
+        <value_map>
+            <name>ZFS zpool scrub status</name>
+            <mappings>
+                <mapping>
+                    <value>0</value>
+                    <newvalue>Scrub in progress</newvalue>
+                </mapping>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>No scrub in progress</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+    </value_maps>
+</zabbix_export>

--- a/template/zol_template_passive.xml
+++ b/template/zol_template_passive.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
-    <version>5.0</version>
-    <date>2021-03-08T19:05:43Z</date>
+    <version>4.4</version>
+    <date>2021-03-09T20:56:51Z</date>
     <groups>
         <group>
             <name>Templates</name>


### PR DESCRIPTION
Sometimes you're really needed in passive checks, but there is no ready-to-use template available. E.g., we should use active checks for temporary cloud instances while we use passive checks for static infrastructure. Currently zabbix 5.0LTS suports not so much conditions in active check actions, so we can't use them for static infrasctructure.