### PR TITLE
Add option to display a whole pool's status instead of just single vdevs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ I have maintained and modified this template over the years and the different ve
 
 Thanks to external contributors, this template was extended and is now more complete than ever. However, if you find a metric that you need and is missing, don't hesitate to open a ticket or even better, to create a PR!
 
-Tested Zabbix server version include 4.0, 4.4, 5.0 and 5.2 . The template shipped here is in 4.0 format to allow import to all those versions.
+Tested Zabbix server version include 4.0, 4.4, 5.0, 5.2 and 5.4 . The template shipped here is in 4.0 format to allow import to all those versions.
 
 This template will give you screens and graphs for memory usage, zpool usage and performance, dataset usage, etc. It includes triggers for low disk space (customizable via Zabbix own macros), disks errors, etc.
 

--- a/template/zol_template.xml
+++ b/template/zol_template.xml
@@ -2404,6 +2404,69 @@ Home of the project: https://github.com/Cosium/zabbix_zfs-on-linux</description>
                             <master_item/>
                         </item_prototype>
                         <item_prototype>
+                            <name>Zpool {#POOLNAME} Status</name>
+                            <type>7</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>zfs.zpool.status[{#POOLNAME}]</key>
+                            <delay>5m</delay>
+                            <history>30d</history>
+                            <trends>0</trends>
+                            <status>0</status>
+                            <value_type>4</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications>
+                                <application>
+                                    <name>ZFS</name>
+                                </application>
+                                <application>
+                                    <name>ZFS zpool</name>
+                                </application>
+                            </applications>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes/>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
                             <name>Zpool {#POOLNAME} read throughput</name>
                             <type>18</type>
                             <snmp_community/>

--- a/userparameters/ZoL_with_sudo.conf
+++ b/userparameters/ZoL_with_sudo.conf
@@ -11,7 +11,7 @@ UserParameter=zfs.vdev.discovery,/usr/bin/sudo /sbin/zpool list -Hv | grep '^[[:
 
 # pool health
 UserParameter=zfs.zpool.health[*],/usr/bin/sudo /sbin/zpool list -H -o health $1
-UserParameter=zfs.zpool.health[*],/usr/bin/sudo /sbin/zpool status $1
+UserParameter=zfs.zpool.status[*],/usr/bin/sudo /sbin/zpool status $1
 
 # get any fs option
 UserParameter=zfs.get.fsinfo[*],/usr/bin/sudo /sbin/zfs get -o value -Hp $2 $1

--- a/userparameters/ZoL_with_sudo.conf
+++ b/userparameters/ZoL_with_sudo.conf
@@ -11,6 +11,7 @@ UserParameter=zfs.vdev.discovery,/usr/bin/sudo /sbin/zpool list -Hv | grep '^[[:
 
 # pool health
 UserParameter=zfs.zpool.health[*],/usr/bin/sudo /sbin/zpool list -H -o health $1
+UserParameter=zfs.zpool.health[*],/usr/bin/sudo /sbin/zpool status $1
 
 # get any fs option
 UserParameter=zfs.get.fsinfo[*],/usr/bin/sudo /sbin/zfs get -o value -Hp $2 $1

--- a/userparameters/ZoL_without_sudo.conf
+++ b/userparameters/ZoL_without_sudo.conf
@@ -11,6 +11,7 @@ UserParameter=zfs.vdev.discovery,/sbin/zpool list -Hv | grep '^[[:blank:]]' | eg
 
 # pool health
 UserParameter=zfs.zpool.health[*],/sbin/zpool list -H -o health $1
+UserParameter=zfs.zpool.health[*],/sbin/zpool status $1
 
 # get any fs option
 UserParameter=zfs.get.fsinfo[*],/sbin/zfs get -o value -Hp $2 $1

--- a/userparameters/ZoL_without_sudo.conf
+++ b/userparameters/ZoL_without_sudo.conf
@@ -11,7 +11,7 @@ UserParameter=zfs.vdev.discovery,/sbin/zpool list -Hv | grep '^[[:blank:]]' | eg
 
 # pool health
 UserParameter=zfs.zpool.health[*],/sbin/zpool list -H -o health $1
-UserParameter=zfs.zpool.health[*],/sbin/zpool status $1
+UserParameter=zfs.zpool.status[*],/sbin/zpool status $1
 
 # get any fs option
 UserParameter=zfs.get.fsinfo[*],/sbin/zfs get -o value -Hp $2 $1


### PR DESCRIPTION
I personally missed the option to display a pool's status, which I prefer to listing all the single vdevs' status, so that the characteristic overview
```
pool: zfileserver
state: ONLINE
scan: scrub repaired 0B in 00:11:38 with 0 errors on Sun Jul 11 00:35:39 2021
config:
	NAME         STATE     READ WRITE CKSUM
	zfileserver  ONLINE       0     0     0
	  raidz2-0   ONLINE       0     0     0
	    sda      ONLINE       0     0     0
	    sdb      ONLINE       0     0     0
	    ...

errors: No known data errors
```
can be displayed in a widget.